### PR TITLE
Add more useful tracing features for Jerry

### DIFF
--- a/clients/fuse/include/iFuseLib.Http.h
+++ b/clients/fuse/include/iFuseLib.Http.h
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <time.h>
 
+// defaults
 #ifndef HTTP_LOG_SERVER_HOSTNAME
 #define HTTP_LOG_SERVER_HOSTNAME "malloy.iplantcollaborative.org"
 #endif 
@@ -30,12 +31,17 @@
 #define HTTP_LOG_SYNC_TIMEOUT 60
 #endif
 
+#ifndef HTTP_LOG_MAX_LINES
+#define HTTP_LOG_MAX_LINES      10000
+#endif
+
 #define xstr(s) str(s)
 #define str(s) #s
 
 #define HTTP_LOG_SERVER_PORTNUM_STR     xstr(HTTP_LOG_SERVER_PORTNUM)
 #define HTTP_LOG_SERVER_TIMEOUT_STR     xstr(HTTP_LOG_SERVER_TIMEOUT)
 #define HTTP_LOG_SYNC_TIMEOUT_STR       xstr(HTTP_LOG_SYNC_TIMEOUT)
+#define HTTP_LOG_MAX_LINES_STR          xstr(HTTP_LOG_MAX_LINES)
 
 #ifdef  __cplusplus
 extern "C" {

--- a/clients/fuse/include/iFuseLib.Logging.h
+++ b/clients/fuse/include/iFuseLib.Logging.h
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <memory.h>
 #include <unistd.h>
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
@@ -20,12 +21,14 @@
 #define LOG_FILENAME_SALT "dasc46hbQWo8GZ2pI6Mw7Vknxdb9HIiUSaaPf9hh3QVgu4HrVrOnC3wMcQc2bxsDqDsJim1kXNx4qbb9eELYE8Jdzok3PZgiV3GRRBhPs0Zo49bBsmidJT4v50pJEOpo"
 #endif 
 
-#define LOG_PATH_FMT                    "/tmp/irods.log.XXXXXX"
+// defauls
+#define LOG_PATH_DIR                    "/tmp/"
+#define LOG_PATH_FMT                    "irods.log.XXXXXX"
 
 #define LOG_PATH_HASH_LEN (2 * SHA256_DIGEST_LENGTH + 1)
 
-#define WHERESTR "%05d:%05d: [%16s:%04u] %s @%ld.%ld: "
-#define WHEREARG (int)getpid(), (int)gettid(), __FILE__, __LINE__, __func__
+#define WHERESTR "%05d:%05d: %s @%ld.%ld: "
+#define WHEREARG (int)getpid(), (int)gettid(), __func__
 
 typedef std::vector<char*> log_sync_buf_t;
 
@@ -34,10 +37,13 @@ struct log_context {
    pthread_t rollover_thread;           // for compressing the logs and rolling them over 
    pthread_t sync_thread;               // for sending off compressed logs to the log server
    sem_t sync_sem;                      // for signaling the sync thread to wake up and try synchronizing logs
+   sem_t rollover_sem;                  // for signaling the log rollover thread to wake up and roll over the logs
    
    pthread_rwlock_t lock;               // govern access to this structure
    
-   FILE* logfile;                       // current open logfile
+   FILE* logfile_pipe;                  // current open logfile (pipe)
+   int tmpfd;                           // current open temporary file that holds the final data
+   char* logfile_dir;                   // directory in which to create logs
    char* logfile_path;                  // path to the current open logfile 
    
    char* log_path_salt;                 // salt to use when hashing paths
@@ -50,16 +56,31 @@ struct log_context {
    log_sync_buf_t* sync_buf;            // list of paths to compressed log files that the sync thread should send off
    
    int running;                         // set to 1 if the threads are running; 0 otherwise
+   
+   int num_lines;                       // number of lines logged
+   int max_lines;                       // maximum number of lines to log before rolling over
+   
+   uint64_t methods;                    // bitfield of which methods to log
 };
 
-#define logmsg( logctx, format, ... ) \
+#define log_maybe_signal_rollover( logctx ) \
+   (logctx)->num_lines++; \
+   if( (logctx)->num_lines > (logctx)->max_lines ) { \
+      (logctx)->num_lines = 0; \
+      sem_post( &(logctx)->rollover_sem ); \
+   }
+
+#define logmsg( logctx, method, format, ... ) \
    do { \
       if( (logctx) != NULL ) { \
-         pthread_rwlock_rdlock( &(logctx)->lock ); \
-         struct timespec _ts; \
-         clock_gettime( CLOCK_MONOTONIC, &_ts ); \
-         fprintf( (logctx)->logfile, WHERESTR "INFO: " format, WHEREARG, _ts.tv_sec, _ts.tv_nsec, __VA_ARGS__);\
-         pthread_rwlock_unlock( &(logctx)->lock ); \
+         if( ((logctx)->methods & method) != 0 ) { \
+            pthread_rwlock_rdlock( &(logctx)->lock ); \
+            struct timespec _ts; \
+            clock_gettime( CLOCK_MONOTONIC, &_ts ); \
+            fprintf( (logctx)->logfile_pipe, WHERESTR "INFO: " format, WHEREARG, _ts.tv_sec, _ts.tv_nsec, __VA_ARGS__);\
+            log_maybe_signal_rollover( logctx ); \
+            pthread_rwlock_unlock( &(logctx)->lock ); \
+         }\
       } \
    } while(0)
    
@@ -69,7 +90,8 @@ struct log_context {
          pthread_rwlock_rdlock( &(logctx)->lock ); \
          struct timespec _ts; \
          clock_gettime( CLOCK_MONOTONIC, &_ts ); \
-         fprintf( (logctx)->logfile, WHERESTR "ERR : " format, WHEREARG, _ts.tv_sec, _ts.tv_nsec, __VA_ARGS__); \
+         fprintf( (logctx)->logfile_pipe, WHERESTR "ERR : " format, WHEREARG, _ts.tv_sec, _ts.tv_nsec, __VA_ARGS__); \
+         log_maybe_signal_rollover( logctx ); \
          pthread_rwlock_unlock( &(logctx)->lock ); \
       } \
    } while(0)
@@ -80,7 +102,7 @@ extern "C" {
 
 void log_hash_path( struct log_context* ctx, char const* path, char hash_buf[LOG_PATH_HASH_LEN] );
 
-struct log_context* log_init( char const* http_server, int http_port, int sync_delay, int timeout, char const* log_path_salt );
+struct log_context* log_init( char const* http_server, int http_port, int sync_delay, int timeout, int max_lines, uint64_t methods, char const* log_path_salt, char const* log_dir );
 int log_free( struct log_context* logctx );
 int log_start_threads( struct log_context* logctx );
 int log_stop_threads( struct log_context* logctx );

--- a/clients/fuse/include/iFuseLib.Trace.h
+++ b/clients/fuse/include/iFuseLib.Trace.h
@@ -1,11 +1,17 @@
 #ifndef I_FUSELIB_TRACE_H
 #define I_FUSELIB_TRACE_H
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
+
 // trace wrappers around the irods Fuse operations
 #include <sys/statvfs.h>
 
 // don't include if all we're doing is testing the trace functionality
-#ifndef TEST_TRACE
+#ifndef _TEST_TRACE
 #include "rodsClient.h"
 #include "rodsPath.h"
 #include "iFuseLib.h"
@@ -19,8 +25,35 @@
 extern "C" {
 #endif
 
+#define TRACE_GETATTR   0x1
+#define TRACE_READLINK  0x2
+#define TRACE_MKNOD     0x4
+#define TRACE_MKDIR     0x8
+#define TRACE_UNLINK    0x10
+#define TRACE_RMDIR     0x20
+#define TRACE_SYMLINK   0x40
+#define TRACE_RENAME    0x80
+#define TRACE_LINK      0x100
+#define TRACE_CHMOD     0x200
+#define TRACE_CHOWN     0x400
+#define TRACE_TRUNCATE  0x800
+#define TRACE_FLUSH     0x1000
+#define TRACE_UTIMENS   0x2000
+#define TRACE_OPEN      0x4000
+#define TRACE_READ      0x8000
+#define TRACE_WRITE     0x10000
+#define TRACE_STATFS    0x20000
+#define TRACE_RELEASE   0x40000
+#define TRACE_FSYNC     0x80000
+#define TRACE_READDIR   0x100000
+   
+#define TRACE_DEBUG     0x200000
+   
+#define TRACE_ALL       0x3FFFFF
+
 // don't compile these if all we're doing is testing the trace functionality
-#ifndef TEST_TRACE
+#ifndef _TEST_TRACE
+
 int traced_irodsGetattr(const char *path, struct stat *stbuf);
 int traced_irodsReadlink(const char *path, char *buf, size_t size);
 int traced_irodsMknod(const char *path, mode_t mode, dev_t rdev);
@@ -40,11 +73,12 @@ int traced_irodsRead(const char *path, char *buf, size_t size, off_t offset, str
 int traced_irodsWrite(const char *path, const char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
 int traced_irodsStatfs(const char *path, struct statvfs *stbuf);
 int traced_irodsRelease(const char *path, struct fuse_file_info *fi);
-int traced_irodsFsync (const char *path, int isdatasync, struct fuse_file_info *fi);
+int traced_irodsFsync(const char *path, int isdatasync, struct fuse_file_info *fi);
 int traced_irodsReaddir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+
 #endif
 
-int trace_get_environment_variables( char** http_host, int* portnum, int* sync_delay, char** log_path_salt );
+int trace_get_environment_variables( char** http_host, int* portnum, int* sync_delay, int* max_lines, uint64_t* methods, char** log_path_salt );
 int trace_read_arg( int argc, char** argv, int i );
 int trace_begin( struct log_context** ctx );
 int trace_end( struct log_context** ctx );

--- a/clients/fuse/src/iFuseLib.Trace.c
+++ b/clients/fuse/src/iFuseLib.Trace.c
@@ -2,6 +2,11 @@
 #include "irodsFs.h"
 #include "iFuseOper.h"
 #include "miscUtil.h"
+
+#else
+
+#define USER_INPUT_OPTION_ERR  -1
+
 #endif 
 
 #include "iFuseLib.Trace.h"
@@ -9,16 +14,16 @@
 struct log_context* LOGCTX = NULL;
 
 
-#ifndef TEST_TRACE
+#ifndef _TEST_TRACE
 int traced_irodsGetattr(const char *path, struct stat *stbuf) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsGetattr(%s, %p)\n", path_hash, stbuf );
+   logmsg( LOGCTX, TRACE_GETATTR, "irodsGetattr(%s, %p)\n", path_hash, stbuf );
 
    int rc = irodsGetattr( path, stbuf );
    
-   logmsg( LOGCTX, "irodsGetattr(%s, %p) rc = %d\n", path_hash, stbuf, rc );
+   logmsg( LOGCTX, TRACE_GETATTR, "irodsGetattr(%s, %p) rc = %d\n", path_hash, stbuf, rc );
    
    return rc;
 }
@@ -27,11 +32,11 @@ int traced_irodsReadlink(const char *path, char *buf, size_t size) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsReadlink(%s, %p, %zu)\n", path_hash, buf, size );
+   logmsg( LOGCTX, TRACE_READLINK, "irodsReadlink(%s, %p, %zu)\n", path_hash, buf, size );
    
    int rc = irodsReadlink( path, buf, size );
    
-   logmsg( LOGCTX, "irodsReadlink(%s, %p, %zu) rc = %d\n", path_hash, buf, size, rc );
+   logmsg( LOGCTX, TRACE_READLINK, "irodsReadlink(%s, %p, %zu) rc = %d\n", path_hash, buf, size, rc );
    
    return rc;
 }
@@ -40,11 +45,11 @@ int traced_irodsMknod(const char *path, mode_t mode, dev_t rdev) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );
-   logmsg( LOGCTX, "irodsMknod(%s, %o, %lX)\n", path_hash, mode, rdev );
+   logmsg( LOGCTX, TRACE_MKNOD, "irodsMknod(%s, %o, %lX)\n", path_hash, mode, rdev );
    
    int rc = irodsMknod( path, mode, rdev );
 
-   logmsg( LOGCTX, "irodsMknod(%s, %o, %lX) rc = %d\n", path_hash, mode, rdev, rc );
+   logmsg( LOGCTX, TRACE_MKNOD, "irodsMknod(%s, %o, %lX) rc = %d\n", path_hash, mode, rdev, rc );
    
    return rc;
 }
@@ -53,11 +58,11 @@ int traced_irodsMkdir(const char *path, mode_t mode) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsMkdir(%s, %o)\n", path_hash, mode );
+   logmsg( LOGCTX, TRACE_MKDIR, "irodsMkdir(%s, %o)\n", path_hash, mode );
    
    int rc = irodsMkdir( path, mode );
    
-   logmsg( LOGCTX, "irodsMkdir(%s, %o) rc = %d\n", path_hash, mode, rc );
+   logmsg( LOGCTX, TRACE_MKDIR, "irodsMkdir(%s, %o) rc = %d\n", path_hash, mode, rc );
    
    return rc;
 }
@@ -66,11 +71,11 @@ int traced_irodsUnlink(const char *path) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsUnlink(%s)\n", path_hash );
+   logmsg( LOGCTX, TRACE_UNLINK, "irodsUnlink(%s)\n", path_hash );
    
    int rc = irodsUnlink( path );
 
-   logmsg( LOGCTX, "irodsUnlink(%s) rc = %d\n", path_hash, rc );
+   logmsg( LOGCTX, TRACE_UNLINK, "irodsUnlink(%s) rc = %d\n", path_hash, rc );
    
    return rc;
 }
@@ -79,11 +84,11 @@ int traced_irodsRmdir(const char *path) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsRmdir(%s)\n", path_hash );
+   logmsg( LOGCTX, TRACE_RMDIR, "irodsRmdir(%s)\n", path_hash );
    
    int rc = irodsRmdir( path );
 
-   logmsg( LOGCTX, "irodsRmdir(%s) rc = %d\n", path_hash, rc );
+   logmsg( LOGCTX, TRACE_RMDIR, "irodsRmdir(%s) rc = %d\n", path_hash, rc );
    
    return rc;
 }
@@ -96,11 +101,11 @@ int traced_irodsSymlink(const char *from, const char *to) {
    log_hash_path( LOGCTX, from, from_hash );    
    log_hash_path( LOGCTX, to, to_hash );
    
-   logmsg( LOGCTX, "irodsSymlink(%s, %s)\n", from_hash, to_hash );
+   logmsg( LOGCTX, TRACE_SYMLINK, "irodsSymlink(%s, %s)\n", from_hash, to_hash );
    
    int rc = irodsSymlink( from, to );
 
-   logmsg( LOGCTX, "irodsSymlink(%s, %s) rc = %d\n", from_hash, to_hash, rc );
+   logmsg( LOGCTX, TRACE_SYMLINK, "irodsSymlink(%s, %s) rc = %d\n", from_hash, to_hash, rc );
    
    return rc;
 }
@@ -113,11 +118,11 @@ int traced_irodsRename(const char *from, const char *to) {
    log_hash_path( LOGCTX, from, from_hash );    
    log_hash_path( LOGCTX, to, to_hash );
    
-   logmsg( LOGCTX, "irodsRename(%s, %s)\n", from_hash, to_hash );
+   logmsg( LOGCTX, TRACE_RENAME, "irodsRename(%s, %s)\n", from_hash, to_hash );
    
    int rc = irodsRename( from, to );
 
-   logmsg( LOGCTX, "irodsRename(%s, %s) rc = %d\n", from_hash, to_hash, rc );
+   logmsg( LOGCTX, TRACE_RENAME, "irodsRename(%s, %s) rc = %d\n", from_hash, to_hash, rc );
    
    return rc;
 }
@@ -130,11 +135,11 @@ int traced_irodsLink(const char *from, const char *to) {
    log_hash_path( LOGCTX, from, from_hash );    
    log_hash_path( LOGCTX, to, to_hash );
    
-   logmsg( LOGCTX, "irodsLink(%s, %s)", from_hash, to_hash );
+   logmsg( LOGCTX, TRACE_LINK, "irodsLink(%s, %s)", from_hash, to_hash );
    
    int rc = irodsLink( from, to );
 
-   logmsg( LOGCTX, "irodsLink(%s, %s) rc = %d", from_hash, to_hash, rc );
+   logmsg( LOGCTX, TRACE_LINK, "irodsLink(%s, %s) rc = %d", from_hash, to_hash, rc );
    
    return rc;
 }
@@ -143,11 +148,11 @@ int traced_irodsChmod(const char *path, mode_t mode) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsChmod(%s, %o)\n", path_hash, mode );
+   logmsg( LOGCTX, TRACE_CHMOD, "irodsChmod(%s, %o)\n", path_hash, mode );
    
    int rc = irodsChmod( path, mode );
 
-   logmsg( LOGCTX, "irodsChmod(%s, %o) rc = %d\n", path_hash, mode, rc );
+   logmsg( LOGCTX, TRACE_CHMOD, "irodsChmod(%s, %o) rc = %d\n", path_hash, mode, rc );
    
    return rc;
 }
@@ -156,11 +161,11 @@ int traced_irodsChown(const char *path, uid_t uid, gid_t gid) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsChown(%s, %d, %d)\n", path_hash, uid, gid);
+   logmsg( LOGCTX, TRACE_CHOWN, "irodsChown(%s, %d, %d)\n", path_hash, uid, gid);
    
    int rc = irodsChown( path, uid, gid );
 
-   logmsg( LOGCTX, "irodsChown(%s, %d, %d) rc = %d\n", path_hash, uid, gid, rc);
+   logmsg( LOGCTX, TRACE_CHOWN, "irodsChown(%s, %d, %d) rc = %d\n", path_hash, uid, gid, rc);
    
    return rc;
 }
@@ -169,11 +174,11 @@ int traced_irodsTruncate(const char *path, off_t size) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsTruncate(%s, %zu)\n", path_hash, size);
+   logmsg( LOGCTX, TRACE_TRUNCATE, "irodsTruncate(%s, %zu)\n", path_hash, size);
    
    int rc = irodsTruncate( path, size );
 
-   logmsg( LOGCTX, "irodsTruncate(%s, %zu) rc = %d\n", path_hash, size, rc);
+   logmsg( LOGCTX, TRACE_TRUNCATE, "irodsTruncate(%s, %zu) rc = %d\n", path_hash, size, rc);
    
    return rc;
 }
@@ -182,11 +187,11 @@ int traced_irodsFlush(const char *path, struct fuse_file_info *fi) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsFlush(%s, %p)\n", path_hash, fi);
+   logmsg( LOGCTX, TRACE_FLUSH, "irodsFlush(%s, %p)\n", path_hash, fi);
    
    int rc = irodsFlush( path, fi );
 
-   logmsg( LOGCTX, "irodsFlush(%s, %p) rc = %d\n", path_hash, fi, rc);
+   logmsg( LOGCTX, TRACE_FLUSH, "irodsFlush(%s, %p) rc = %d\n", path_hash, fi, rc);
    
    return rc;
 }
@@ -195,11 +200,11 @@ int traced_irodsUtimens (const char *path, const struct timespec ts[]) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsUtimens(%s, %ld, %ld, %ld, %ld)\n", path_hash, ts[0].tv_sec, ts[0].tv_nsec, ts[1].tv_sec, ts[1].tv_nsec );
+   logmsg( LOGCTX, TRACE_UTIMENS, "irodsUtimens(%s, %ld, %ld, %ld, %ld)\n", path_hash, ts[0].tv_sec, ts[0].tv_nsec, ts[1].tv_sec, ts[1].tv_nsec );
    
    int rc = irodsUtimens( path, ts );
 
-   logmsg( LOGCTX, "irodsUtimens(%s, %ld, %ld, %ld, %ld) rc = %d\n", path_hash, ts[0].tv_sec, ts[0].tv_nsec, ts[1].tv_sec, ts[1].tv_nsec, rc );
+   logmsg( LOGCTX, TRACE_UTIMENS, "irodsUtimens(%s, %ld, %ld, %ld, %ld) rc = %d\n", path_hash, ts[0].tv_sec, ts[0].tv_nsec, ts[1].tv_sec, ts[1].tv_nsec, rc );
    
    return rc;
 }
@@ -208,11 +213,11 @@ int traced_irodsOpen(const char *path, struct fuse_file_info *fi) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsOpen(%s, %p, flags=%X)\n", path_hash, fi, fi->flags );
+   logmsg( LOGCTX, TRACE_OPEN, "irodsOpen(%s, %p, flags=%X)\n", path_hash, fi, fi->flags );
    
    int rc = irodsOpen( path, fi );
 
-   logmsg( LOGCTX, "irodsOpen(%s, %p, flags=%X) rc = %d\n", path_hash, fi, fi->flags, rc );
+   logmsg( LOGCTX, TRACE_OPEN, "irodsOpen(%s, %p, flags=%X) rc = %d\n", path_hash, fi, fi->flags, rc );
    
    return rc;
 }
@@ -221,11 +226,11 @@ int traced_irodsRead(const char *path, char *buf, size_t size, off_t offset, str
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsRead(%s, %p, %zu, %jd, %p)\n", path_hash, buf, size, offset, fi);
+   logmsg( LOGCTX, TRACE_READ, "irodsRead(%s, %p, %zu, %jd, %p)\n", path_hash, buf, size, offset, fi);
    
    int rc = irodsRead( path, buf, size, offset, fi );
 
-   logmsg( LOGCTX, "irodsRead(%s, %p, %zu, %jd, %p) rc = %d\n", path_hash, buf, size, offset, fi, rc);
+   logmsg( LOGCTX, TRACE_READ, "irodsRead(%s, %p, %zu, %jd, %p) rc = %d\n", path_hash, buf, size, offset, fi, rc);
    
    return rc;
 }
@@ -234,11 +239,11 @@ int traced_irodsWrite(const char *path, const char *buf, size_t size, off_t offs
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsWrite(%s, %p, %zu, %jd, %p)\n", path_hash, buf, size, offset, fi );
+   logmsg( LOGCTX, TRACE_WRITE, "irodsWrite(%s, %p, %zu, %jd, %p)\n", path_hash, buf, size, offset, fi );
    
    int rc = irodsWrite( path, buf, size, offset, fi );
 
-   logmsg( LOGCTX, "irodsWrite(%s, %p, %zu, %jd, %p) rc = %d\n", path_hash, buf, size, offset, fi, rc );
+   logmsg( LOGCTX, TRACE_WRITE, "irodsWrite(%s, %p, %zu, %jd, %p) rc = %d\n", path_hash, buf, size, offset, fi, rc );
    
    return rc;
 }
@@ -247,11 +252,11 @@ int traced_irodsStatfs(const char *path, struct statvfs *stbuf) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsStatfs(%s, %p)\n", path_hash, stbuf );
+   logmsg( LOGCTX, TRACE_STATFS, "irodsStatfs(%s, %p)\n", path_hash, stbuf );
    
    int rc = irodsStatfs( path, stbuf );
 
-   logmsg( LOGCTX, "irodsStatfs(%s, %p) rc = %d\n", path_hash, stbuf, rc );
+   logmsg( LOGCTX, TRACE_STATFS, "irodsStatfs(%s, %p) rc = %d\n", path_hash, stbuf, rc );
    
    return rc;
 }
@@ -260,11 +265,11 @@ int traced_irodsRelease(const char *path, struct fuse_file_info *fi) {
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsRelease(%s, %p)\n", path_hash, fi );
+   logmsg( LOGCTX, TRACE_RELEASE, "irodsRelease(%s, %p)\n", path_hash, fi );
    
    int rc = irodsRelease( path, fi );
 
-   logmsg( LOGCTX, "irodsRelease(%s, %p) rc = %d\n", path_hash, fi, rc );
+   logmsg( LOGCTX, TRACE_RELEASE, "irodsRelease(%s, %p) rc = %d\n", path_hash, fi, rc );
    
    return rc;
 }
@@ -273,11 +278,11 @@ int traced_irodsFsync (const char *path, int isdatasync, struct fuse_file_info *
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsFsync(%s, %d, %p)\n", path_hash, isdatasync, fi );
+   logmsg( LOGCTX, TRACE_FSYNC, "irodsFsync(%s, %d, %p)\n", path_hash, isdatasync, fi );
    
    int rc = irodsFsync( path, isdatasync, fi );
    
-   logmsg( LOGCTX, "irodsFsync(%s, %d, %p) rc = %d\n", path_hash, isdatasync, fi, rc );
+   logmsg( LOGCTX, TRACE_FSYNC, "irodsFsync(%s, %d, %p) rc = %d\n", path_hash, isdatasync, fi, rc );
    
    return rc;
 }
@@ -286,26 +291,100 @@ int traced_irodsReaddir(const char *path, void *buf, fuse_fill_dir_t filler, off
    
    char path_hash[LOG_PATH_HASH_LEN];
    log_hash_path( LOGCTX, path, path_hash );    
-   logmsg( LOGCTX, "irodsReaddir(%s, %p, %p, %jd, %p)\n", path_hash, buf, filler, offset, fi );
+   logmsg( LOGCTX, TRACE_READDIR, "irodsReaddir(%s, %p, %p, %jd, %p)\n", path_hash, buf, filler, offset, fi );
    
    int rc = irodsReaddir( path, buf, filler, offset, fi );
 
-   logmsg( LOGCTX, "irodsReaddir(%s, %p, %p, %jd, %p) rc = %d\n", path_hash, buf, filler, offset, fi, rc );
+   logmsg( LOGCTX, TRACE_READDIR, "irodsReaddir(%s, %p, %p, %jd, %p) rc = %d\n", path_hash, buf, filler, offset, fi, rc );
    
    return rc;
 }
 #endif
 
 
-int trace_get_environment_variables( char** http_host, int* portnum, int* sync_delay, int* timeout, char** path_salt ) {
+struct trace_method_to_bit {
+   char const* method_name;
+   uint64_t bit;
+};
+
+int trace_get_methods_mask( char const* methods_csv_const, uint64_t* ret_mask ) {
+   
+   static const struct trace_method_to_bit trace_bits[] = {
+      {"getattr",               TRACE_GETATTR},
+      {"readlink",              TRACE_READLINK},
+      {"mknod",                 TRACE_MKNOD},
+      {"mkdir",                 TRACE_MKDIR},
+      {"unlink",                TRACE_UNLINK},
+      {"rmdir",                 TRACE_RMDIR},
+      {"symlink",               TRACE_SYMLINK},
+      {"rename",                TRACE_RENAME},
+      {"link",                  TRACE_LINK},
+      {"chmod",                 TRACE_CHMOD},
+      {"chown",                 TRACE_CHOWN},
+      {"truncate",              TRACE_TRUNCATE},
+      {"flush",                 TRACE_FLUSH},
+      {"utimens",               TRACE_UTIMENS},
+      {"open",                  TRACE_OPEN},
+      {"read",                  TRACE_READ},
+      {"write",                 TRACE_WRITE},
+      {"statfs",                TRACE_STATFS},
+      {"release",               TRACE_RELEASE},
+      {"fsync",                 TRACE_FSYNC},
+      {"readdir",               TRACE_READDIR},
+      {"all",                   TRACE_ALL},
+      {NULL,                    0}
+   };
+   
+   char* tmp = NULL;
+   char* methods_csv = strdup( methods_csv_const );
+   char* method_tok = NULL;
+   char* methods_csv_strtok = methods_csv;
+   uint64_t mask = 0;
+   
+   if( methods_csv == NULL ) {
+      return -ENOMEM;
+   }
+   
+   // tokenize by ',' and ' '
+   while( 1 ) {
+      
+      method_tok = strtok_r( methods_csv_strtok, ", ", &tmp );
+      methods_csv_strtok = NULL;
+      
+      if( method_tok == NULL ) {
+         // end 
+         break;
+      }
+      
+      // find method
+      for( int i = 0; trace_bits[i].method_name != NULL; i++ ) {
+         
+         if( strcmp( trace_bits[i].method_name, method_tok ) == 0 ) {
+            mask |= trace_bits[i].bit;
+         }
+      }
+   }
+   
+   free( methods_csv );
+   *ret_mask = mask;
+   
+   return 0;
+}
+
+
+int trace_get_environment_variables( char** http_host, int* portnum, int* sync_delay, int* timeout, int* max_lines, uint64_t* methods, char** path_salt, char** log_dir ) {
    
    // get the environment 
    *http_host = strdup_or_default( getenv("IRODSFS_LOG_SERVER_HOSTNAME"), HTTP_LOG_SERVER_HOSTNAME );
    *path_salt = strdup_or_default( getenv("IRODSFS_LOG_PATH_SALT"), LOG_FILENAME_SALT );
+   *log_dir = strdup_or_default( getenv("IRODSFS_LOG_DIR"), LOG_PATH_DIR );
    
    char* http_port_str = strdup_or_default( getenv("IRODSFS_LOG_SERVER_PORTNUM"), HTTP_LOG_SERVER_PORTNUM_STR );
    char* sync_delay_str = strdup_or_default( getenv("IRODSFS_LOG_SERVER_SYNC_DELAY"), HTTP_LOG_SYNC_TIMEOUT_STR );
    char* timeout_str = strdup_or_default( getenv("IRODSFS_LOG_SERVER_TIMEOUT"), HTTP_LOG_SERVER_TIMEOUT_STR );
+   char* max_lines_str = strdup_or_default( getenv("IRODSFS_LOG_MAX_LINES"), HTTP_LOG_MAX_LINES_STR );
+   char* methods_csv = strdup_or_default( getenv("IRODSFS_LOG_METHODS"), "all" );
+   int rc = 0;
    
    // parse!
    char* tmp = NULL;
@@ -325,15 +404,40 @@ int trace_get_environment_variables( char** http_host, int* portnum, int* sync_d
    }
    
    *timeout = (int)strtoll( timeout_str, &tmp, 10 );
-   if( tmp == NULL || &timeout <= 0 ) {
+   if( tmp == NULL || *timeout <= 0 ) {
       
       fprintf(stderr, "WARN: invalid timeout delay of %d seconds.  Using default of %d seconds\n", *timeout, HTTP_LOG_SERVER_TIMEOUT );
       *timeout = HTTP_LOG_SERVER_TIMEOUT;
    }
    
+   *max_lines = (int)strtoll( max_lines_str, &tmp, 10 );
+   if( tmp == NULL || *max_lines <= 0 ) {
+      
+      fprintf(stderr, "WARN: invalid maximum line count %d.  Using default of %d lines\n", *max_lines, HTTP_LOG_MAX_LINES );
+      *max_lines = HTTP_LOG_MAX_LINES;
+   }
+   
+   rc = trace_get_methods_mask( methods_csv, methods );
+   if( rc != 0 ) {
+      
+      fprintf(stderr, "WARN: invalid methods list '%s'.  Using default of '%s'\n", methods_csv, "all" );
+      *methods = TRACE_ALL;
+   }
+   
    free( http_port_str );
    free( sync_delay_str );
    free( timeout_str );
+   
+#ifdef _TEST_TRACE
+   printf("ENV: IRODSFS_LOG_SERVER_HOSTNAME   = %s\n", *http_host );
+   printf("ENV: IRODSFS_LOG_SERVER_PORTNUM    = %d\n", *portnum );
+   printf("ENV: IRODSFS_LOG_PATH_SALT         = %s\n", *path_salt );
+   printf("ENV: IRODSFS_LOG_DIR               = %s\n", *log_dir );
+   printf("ENV: IRODSFS_LOG_SERVER_SYNC_DELAY = %d\n", *sync_delay );
+   printf("ENV: IRODSFS_LOG_SERVER_TIMEOUT    = %d\n", *timeout );
+   printf("ENV: IRODSFS_LOG_MAX_LINES         = %d\n", *max_lines );
+   printf("ENV: IRODSFS_LOG_METHODS           = %" PRIX64 "\n", *methods );
+#endif
    
    return 0;
 }
@@ -360,14 +464,17 @@ int trace_begin( struct log_context** ret ) {
    // get the environment 
    char* http_host = NULL;
    char* log_path_salt = NULL;
+   char* log_dir = NULL;
    int portnum = 0;
    int sync_delay = 0;
    int timeout = 0;
+   int max_lines = 0;
+   uint64_t methods = 0;
    
-   trace_get_environment_variables( &http_host, &portnum, &sync_delay, &timeout, &log_path_salt );
+   trace_get_environment_variables( &http_host, &portnum, &sync_delay, &timeout, &max_lines, &methods, &log_path_salt, &log_dir );
    
    // set up logging 
-   struct log_context* ctx = log_init( http_host, portnum, sync_delay, timeout, log_path_salt );
+   struct log_context* ctx = log_init( http_host, portnum, sync_delay, timeout, max_lines, methods, log_path_salt, log_dir );
    
    if( ctx == NULL ) {
       // OOM
@@ -392,7 +499,7 @@ int trace_begin( struct log_context** ret ) {
       return rc;
    }
    
-   logmsg( ctx, "%s", "trace_begin\n");
+   logmsg( ctx, TRACE_ALL, "%s", "trace_begin\n");
    
    free( http_host );
    free( log_path_salt );
@@ -418,7 +525,7 @@ int trace_end( struct log_context** ctx ) {
       ctx = &LOGCTX;
    }
 
-   logmsg( *ctx, "%s", "trace_end\n");
+   logmsg( *ctx, TRACE_ALL, "%s", "trace_end\n");
    
    // stop the threads 
    rc = log_stop_threads( *ctx );
@@ -448,7 +555,7 @@ int trace_end( struct log_context** ctx ) {
 static int trace_setenv_from_argv( char const* varname, int argc, char** argv, int i ) {
    if( i + 2 < argc ) {
       if( argv[i+1][0] == '-' ) {
-         rodsLog( LOG_ERROR, "Required argument for option %s", argv[i] );
+         fprintf(stderr, "Required argument for option %s", argv[i] );
          return USER_INPUT_OPTION_ERR;
       }
       else {
@@ -457,12 +564,14 @@ static int trace_setenv_from_argv( char const* varname, int argc, char** argv, i
       }
    }
    else {
-      rodsLog(LOG_ERROR, "Required argument for option %s", argv[i] );
+      fprintf(stderr, "Required argument for option %s", argv[i] );
       return USER_INPUT_OPTION_ERR;
    }
 
    return 0;
 }
+
+static char* zeroed_argv = (char*)"-Z";
 
 int trace_read_arg( int argc, char** argv, int i ) {
 
@@ -475,6 +584,9 @@ int trace_read_arg( int argc, char** argv, int i ) {
       {"--trace-salt",       "IRODSFS_LOG_PATH_SALT"},
       {"--trace-timeout",    "IRODSFS_LOG_SERVER_TIMEOUT"},
       {"--trace-sync-delay", "IRODSFS_LOG_SERVER_SYNC_DELAY"},
+      {"--trace-max-lines",  "IRODSFS_LOG_MAX_LINES"},
+      {"--trace-methods",    "IRODSFS_LOG_METHODS"},
+      {"--trace-log-dir",    "IRODSFS_LOG_DIR"},
       {NULL, NULL}
    };
 
@@ -490,14 +602,15 @@ int trace_read_arg( int argc, char** argv, int i ) {
          }
 
          // consumed!
-         argv[i] = "-Z";
-         argv[i+1] = "-Z";
+         argv[i] = zeroed_argv;
+         argv[i+1] = zeroed_argv;
          break;
       }
    }
 
    return 0;
 }
+
 
 void trace_usage(void) {
    char const* msgs[] = {
@@ -521,6 +634,16 @@ void trace_usage(void) {
 " ",
 " IRODSFS_LOG_SERVER_SYNC_DELAY    The number of seconds to wait between uploading snapshots",
 "                                  of access traces to the log server.  The default is " HTTP_LOG_SYNC_TIMEOUT_STR,
+" ",
+" IRODSFS_LOG_MAX_LINES            The number of operations to log before trying to upload them to the",
+"                                  log server.  The default is " HTTP_LOG_MAX_LINES_STR,
+" ",
+" IRODSFS_LOG_DIR                  Directory in which to store log files.  The default is " LOG_PATH_DIR,
+" "
+" IRODSFS_LOG_METHODS              Comma-separated list of which methods to log.  Valid options are "
+"                                  getattr, readlink, mknod, mkdir, unlink, rmdir, symlink, reaname, link,"
+"                                  chmod, chown, truncate, flush, utimens, oen, read, write, statfs, fsync,"
+"                                  readdir, release.  Pass \"all\" for every method (this is the default)."
 ""};
    int i;
    for (i=0;;i++) {


### PR DESCRIPTION
Add the following features:
- select individual methods to trace, instead of everything or nothing (but trace everything on by default)
- make the logfile output directory an option
- upload logs once the reach a certain size
- make the log format more terse to save space
- compress the log on the fly by piping it directly through gzip
